### PR TITLE
Fix livereload when working on virtualenv like Vagrant

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -52,7 +52,7 @@
 {{--livereload--}}
 @if ( Config::get('app.debug') )
     <script type="text/javascript">
-        document.write('<script src="//localhost:35729/livereload.js?snipver=1" type="text/javascript"><\/script>')
+        document.write('<script src="'+ location.protocol + '//' + (location.host || 'localhost') +':35729/livereload.js?snipver=1" type="text/javascript"><\/script>')
     </script>
 @endif
 </body>


### PR DESCRIPTION
When working on a virtual environment, you probably won't access your page at localhost (homestead serves app at homestead.app by default). In that case livereload wouldn't work. 
