### PR TITLE
Change .factory to .service to be able to use class for the services

### DIFF
--- a/angular/index.services.js
+++ b/angular/index.services.js
@@ -3,6 +3,6 @@ import {DialogService} from './services/dialog.service';
 import {ToastService} from './services/toast.service';
 
 angular.module('app.services')
-	.factory('API', APIService)
-	.factory('DialogService', DialogService)
-	.factory('ToastService', ToastService)
+	.service('API', APIService)
+	.service('DialogService', DialogService)
+	.service('ToastService', ToastService)


### PR DESCRIPTION
Had to change .factory to .service to be able to use the "class" call on the services.

This is due to the fact that factories are considered callable functions and not "classes", so using the class declarator doesn't work on them.

If you want them to be factories still let me know I'll change the other services to functions
