### PR TITLE
->see(422) throws error

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -60,7 +60,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
 
     public function seeApiError($error_code)
     {
-        return $this->see($error_code)
+        return $this->assertResponseStatus($error_code)
         ->see('"errors":{');
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,7 +54,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
 
     public function seeValidationError()
     {
-        return $this->see(422)
+        return $this->assertResponseStatus(422)
         ->see('"errors":{');
     }
 


### PR DESCRIPTION
Using seeValidationError or seeApiError with throws the following error:

```
PHPUnit_Framework_Exception: Argument #2 (No Value) of PHPUnit_Framework_Assert::assertRegExp() must be a string
```

This quick change fixes that.
