### PR TITLE
Added cancel option to Dialog service

### DIFF
--- a/angular/services/dialog.service.js
+++ b/angular/services/dialog.service.js
@@ -22,6 +22,10 @@ export class DialogService {
     hide() {
         return this.$mdDialog.hide();
     }
+    
+    cancel(){
+        return this.$mdDialog.cancel();
+    }
 
     alert(title, content) {
         let alert = this.$mdDialog.alert()


### PR DESCRIPTION
hide() returns a promise when the dialog closes, and the cancel function does not, i believe the hide() it's implemented on success buttons, and cancel well in cancel buttons
