### PR TITLE
Added params to hide function

### DIFF
--- a/angular/services/dialog.service.js
+++ b/angular/services/dialog.service.js
@@ -19,8 +19,8 @@ export class DialogService {
         return this.$mdDialog.show(options);
     }
 
-    hide() {
-        return this.$mdDialog.hide();
+    hide(params) {
+        return this.$mdDialog.hide(params);
     }
     
     cancel(){

--- a/angular/services/dialog.service.js
+++ b/angular/services/dialog.service.js
@@ -22,13 +22,13 @@ export class DialogService {
     hide(params) {
         return this.$mdDialog.hide(params);
     }
-    
+
     cancel(){
         return this.$mdDialog.cancel();
     }
 
-    alert(title, content) {
-        let alert = this.$mdDialog.alert()
+    alert(title, content, params) {
+        let alert = this.$mdDialog.alert(params)
             .title(title)
             .content(content)
             .ariaLabel(content)
@@ -37,8 +37,8 @@ export class DialogService {
         this.$mdDialog.show(alert);
     }
 
-    confirm(title, content) {
-        let confirm = this.$mdDialog.confirm()
+    confirm(title, content, params) {
+        let confirm = this.$mdDialog.confirm(params)
             .title(title)
             .content(content)
             .ariaLabel(content)
@@ -48,8 +48,8 @@ export class DialogService {
         return this.$mdDialog.show(confirm);
     }
 
-    prompt(title, content, placeholder) {
-        let prompt = this.$mdDialog.prompt()
+    prompt(title, content, placeholder, params) {
+        let prompt = this.$mdDialog.prompt(params)
             .title(title)
             .textContent(content)
             .placeholder(placeholder)


### PR DESCRIPTION
The $mdDialog.hide() returna  promise, and it accepts params, to use it as  `$mdDialog.show(options).then(function(params) {});`
