### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,11 +12,11 @@
   ],
   "dependencies": {
     "angular": "~1.5",
-    "angular-ui-router": "~0.2.15",
-    "ngstorage": "~0.3.3",
-    "angular-material": "~1.1",
+    "angular-ui-router": "~1.0.0-alpha.3",
+    "ngstorage": "~0.3.10",
+    "angular-material": "~1.0.8",
     "restangular": "~1.5.2",
-    "angular-loading-bar": "~0.8.0",
+    "angular-loading-bar": "~0.9.0",
     "satellizer": "^0.14.0"
   }
 }


### PR DESCRIPTION
The must have update dependencie is the `angular-ui-router` simply because it now support the components as template as mention here https://github.com/angular-ui/ui-router/issues/2627 although you could just do `template: '<your-component></your-component>'` it feels more natural to do `component: 'component-name'` the other ones, just to have everything updated
