### PR TITLE
Updated for the new transitions hooks

### DIFF
--- a/angular/run/routes.run.js
+++ b/angular/run/routes.run.js
@@ -1,17 +1,17 @@
-export function RoutesRun($rootScope, $state, $auth) {
+export function RoutesRun($state, $transitions) {
     'ngInject';
 
+    let requiresAuthCriteria = {
+        to: ($state) => $state.data && $state.data.auth
+    };
 
-    let deregisterationCallback =  $rootScope.$on("$stateChangeStart", function(event, toState) {
-
-        if (toState.data && toState.data.auth) {
-            /*Cancel going to the authenticated state and go back to the login page*/
-            if (!$auth.isAuthenticated()) {
-                event.preventDefault();
-                return $state.go('app.login');
-            }
+    let redirectToLogin = ['$auth', '$transition$', ($auth) => {
+        /*Cancel going to the authenticated state and go back to the login page*/
+        if (!$auth.isAuthenticated()) {
+            return $state.target('app.login', undefined, {location: false});
         }
+    }];
 
-    });
-    $rootScope.$on('$destroy', deregisterationCallback)
+    $transitions.onBefore(requiresAuthCriteria, redirectToLogin, {priority:10});
+
 }

--- a/angular/run/routes.run.js
+++ b/angular/run/routes.run.js
@@ -5,12 +5,12 @@ export function RoutesRun($state, $transitions) {
         to: ($state) => $state.data && $state.data.auth
     };
 
-    let redirectToLogin = ['$auth', '$transition$', ($auth) => {
-        /*Cancel going to the authenticated state and go back to the login page*/
+    let redirectToLogin = ($auth) => {
+        'ngInject';
         if (!$auth.isAuthenticated()) {
             return $state.target('app.login', undefined, {location: false});
         }
-    }];
+    };
 
     $transitions.onBefore(requiresAuthCriteria, redirectToLogin, {priority:10});
 


### PR DESCRIPTION
When updated ui-router in #283 didn't realize that the stateChange\* events have been deprecated and disabled by default in ui-router 1.0\* (my bad) and the new way to do this is using the new Transition hooks as explained here: https://github.com/angular-ui/ui-router/releases/tag/1.0.0alpha0 so this fixes #295 
