### PR TITLE
generate the password reset link based on the "app.url" setting

### DIFF
--- a/resources/views/auth/reset_link.blade.php
+++ b/resources/views/auth/reset_link.blade.php
@@ -1,5 +1,5 @@
 Your reset password link:
 
-<a href="http://localhost:8000/#/reset-password/{{$email}}/{{$token}}">
-http://localhost:8000/#/reset-password/{{$email}}/{{$token}}
+<a href="{{config('app.url')}}/#/reset-password/{{$email}}/{{$token}}">
+{{config('app.url')}}/#/reset-password/{{$email}}/{{$token}}
 </a>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
The reset link generated is something like: `http://localhost:8000/#/reset-password/*`, maybe is best to take the app.url config variable to generate that password reset link.

**What is the new behavior?**
If `config('app.url')` equals to 'test.dev', the generated password reset link is:
`http://test.dev/#/reset-password/*`

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Just change the generated password reset link to take what the developer puts on app.url file config...
