### PR TITLE
Remove token query param on get, post, put, delete and custom request functions and add as auth headers

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -99,35 +99,45 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
 
     public function authUserGet($uri, $headers = [])
     {
-        $headers = ['AUthorization' => 'Bearer '.$this->getAuthUserToken()];
+        if(!isset($headers['Authorization'])){
+            $headers['Authorization'] = 'Bearer ' . $this->getAuthUserToken();
+        }
 
         return $this->get($uri, $headers);
     }
 
-    public function authUserPost($uri, $parameters = [])
+    public function authUserPost($uri, $parameters = [], $headers = [])
     {
-        $uri .= '?token='.$this->getAuthUserToken();
+        if(!isset($headers['Authorization'])){
+            $headers['Authorization'] = 'Bearer ' . $this->getAuthUserToken();
+        }
 
-        return $this->post($uri, $parameters);
+        return $this->post($uri, $parameters, $headers);
     }
 
-    public function authUserPut($uri, $parameters = [])
+    public function authUserPut($uri, $parameters = [], $headers = [])
     {
-        $uri .= '?token='.$this->getAuthUserToken();
+        if(!isset($headers['Authorization'])){
+            $headers['Authorization'] = 'Bearer ' . $this->getAuthUserToken();
+        }
 
-        return $this->put($uri, $parameters);
+        return $this->put($uri, $parameters, $headers);
     }
 
-    public function authUserDelete($uri, $parameters = [])
+    public function authUserDelete($uri, $parameters = [], $headers)
     {
-        $uri .= '?token='.$this->getAuthUserToken();
+        if(!isset($headers['Authorization'])){
+            $headers['Authorization'] = 'Bearer ' . $this->getAuthUserToken();
+        }
 
-        return $this->delete($uri, $parameters);
+        return $this->delete($uri, $parameters, $headers);
     }
 
     public function authUserCall($method, $uri, $parameters = [], $cookies = [], $files = [], $server = [], $content = null)
     {
-        $uri .= '?token='.$this->getAuthUserToken();
+        if(!isset($parameters['Authorization'])){
+            $parameters['Authorization'] = 'Bearer ' . $this->getAuthUserToken();
+        }
 
         return $this->call($method, $uri, $parameters, $cookies, $files, $server, $content);
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Bugfix

**What is the current behaviour?** (You can also link to an open issue here)
When attempting to do a POST request with empty or non-empty data the Illuminate Foundation Testing function converts all query params into POST data. Even though query param remains on the URI, the token is passed as POST data too.

My application has no restriction on what params can be passed which resulted in a "token" column not found exception.

`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'token' in 'field list'`

**What is the new behaviour?**
I have removed the token being sent through the URI and it is now passed into the request headers. I can't see any reason why this would break anyones application and tokens should really be passed this way in the first instance.

**Does this PR introduce a breaking change?**
- [ ] No

**Other information**:
No issue created as I found the bug and fixed it myself.
